### PR TITLE
Fixed hud channel overflow

### DIFF
--- a/addons/sourcemod/scripting/bTimes-hud-css.sp
+++ b/addons/sourcemod/scripting/bTimes-hud-css.sp
@@ -14,6 +14,7 @@ ConVar g_cHudRefreshSpeed;
 ConVar g_cSendKeysAlive;
 
 Handle g_hHintTextTimer;
+Handle hText;
 
 bool g_bReplayLoaded;
 bool g_bReplay3Loaded;
@@ -46,6 +47,9 @@ public void OnPluginStart()
 	g_hVelCookie  = RegClientCookie("timer_truevel", "True velocity meter.", CookieAccess_Public);
 	g_hKeysCookie = RegClientCookie("timer_keys",  "Show movement keys on screen.", CookieAccess_Public);
 	SetCookiePrefabMenu(g_hVelCookie, CookieMenu_OnOff, "True velocity meter");
+	
+	//Hud Synchronizer
+	hText = CreateHudSynchronizer();
 }
 
 public void OnAllPluginsLoaded()
@@ -440,12 +444,10 @@ void ShowHudSyncMessage(int client, int target)
 	
 	if(bShowMessage == true)
 	{
-		Handle hText = CreateHudSynchronizer();
 		if(hText != INVALID_HANDLE)
 		{
 			SetHudTextParams(0.005, 0.0, g_cHudRefreshSpeed.FloatValue, 255, 255, 255, 255);
 			ShowSyncHudText(client, hText, sSyncMessage);
-			CloseHandle(hText);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/bTimes-hud.sp
+++ b/addons/sourcemod/scripting/bTimes-hud.sp
@@ -18,6 +18,7 @@ int g_ExpectedValue[3];
 int g_FadeSpeed;
 
 Handle g_hVelCookie;
+Handle hText;
 
 ConVar g_cFadeSpeed;
 ConVar g_cHudSyncPos[2];
@@ -62,6 +63,7 @@ public void OnPluginStart()
 	
 	g_hVelCookie  = RegClientCookie("timer_truevel", "True velocity meter.", CookieAccess_Public);
 	SetCookiePrefabMenu(g_hVelCookie, CookieMenu_OnOff, "True velocity meter");
+	hText = CreateHudSynchronizer();
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
@@ -580,12 +582,10 @@ void ShowSyncMessage(int client, int target)
 	
 	if(bShowMessage == true)
 	{
-		Handle hText = CreateHudSynchronizer();
 		if(hText != INVALID_HANDLE)
 		{
 			SetHudTextParams(g_cHudSyncPos[0].FloatValue, g_cHudSyncPos[1].FloatValue, 3.0, 255, 255, 255, 255);
 			ShowSyncHudText(client, hText, sSyncMessage);
-			CloseHandle(hText);
 		}
 	}
 }


### PR DESCRIPTION
Plugins using huds should work now as intended with bTimes, without randomly disappearing cause of channel overflow.
PS:  didnt test it.